### PR TITLE
Fix potentially incorrect comment parsing

### DIFF
--- a/example/example.c
+++ b/example/example.c
@@ -7,9 +7,9 @@ int main() {
   FILE * f = fopen("example.ini", "rb");
   if(!f)
     return 1;
-  
+
   struct ini_Parser parser;
-  ini_create_file(&parser, f);
+  ini_create_file(&parser, f, ";#", 2);
 
   struct ini_Record record;
   while(true)
@@ -17,7 +17,7 @@ int main() {
     enum ini_Error error = ini_next(&parser, &record);
     if(error != INI_SUCCESS)
       goto cleanup;
-    
+
     switch(record.type) {
       case INI_RECORD_NUL: goto done;
       case INI_RECORD_SECTION:

--- a/example/example.zig
+++ b/example/example.zig
@@ -7,7 +7,7 @@ pub fn main() !void {
 
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer if (gpa.deinit() != .ok) @panic("memory leaked");
-    var parser = ini.parse(gpa.allocator(), file.reader());
+    var parser = ini.parse(gpa.allocator(), file.reader(), ";#");
     defer parser.deinit();
 
     var writer = std.io.getStdOut().writer();

--- a/src/ini.h
+++ b/src/ini.h
@@ -49,12 +49,16 @@ enum ini_Error
 extern void ini_create_buffer(
   struct ini_Parser  * parser,
   char const * data,
-  size_t length
+  size_t data_length,
+  char const * comment_characters,
+  size_t comment_characters_length
 );
 
 extern void ini_create_file(
   struct ini_Parser  * parser,
-  FILE * file
+  FILE * file,
+  char const * comment_characters,
+  size_t comment_characters_length
 );
 
 extern void ini_destroy(struct ini_Parser  * parser);

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -38,6 +38,7 @@ pub fn Parser(comptime Reader: type) type {
     return struct {
         const Self = @This();
 
+        allocator: std.mem.Allocator,
         line_buffer: std.ArrayList(u8),
         reader: Reader,
         comment_characters: []const u8,
@@ -59,14 +60,30 @@ pub fn Parser(comptime Reader: type) type {
                 try self.line_buffer.append(0); // append guaranteed space for sentinel
 
                 var line: []const u8 = self.line_buffer.items;
-                if (std.mem.indexOfAny(u8, line, self.comment_characters)) |index| {
-                    const trimmed_slice = std.mem.trim(u8, line[0..index], whitespace);
-                    const comment = std.mem.trim(u8, line[index..], whitespace);
+                var last_index: usize = 0;
 
-                    if ((trimmed_slice.len > 0 and trimmed_slice[trimmed_slice.len - 1] != '=') or comment.len > 1)
-                        line = trimmed_slice;
-                } else {
-                    line = std.mem.trim(u8, line, whitespace);
+                // handle comments and escaping
+                while (last_index < line.len) {
+                    if (std.mem.indexOfAnyPos(u8, line, last_index, self.comment_characters)) |index| {
+                        // escape character if needed, then skip it (it's not a comment)
+                        if (index > 0) {
+                            const previous_index = index - 1;
+                            const previous_char = line[previous_index];
+
+                            if (previous_char == '\\') {
+                                _ = self.line_buffer.orderedRemove(previous_index);
+
+                                last_index = index + 1;
+                                continue;
+                            }
+                        }
+
+                        line = std.mem.trim(u8, line[0..index], whitespace);
+                    } else {
+                        line = std.mem.trim(u8, line, whitespace);
+                    }
+
+                    break;
                 }
 
                 if (line.len == 0)
@@ -95,6 +112,7 @@ pub fn Parser(comptime Reader: type) type {
 /// Returns a new parser that can read the ini structure
 pub fn parse(allocator: std.mem.Allocator, reader: anytype, comment_characters: []const u8) Parser(@TypeOf(reader)) {
     return Parser(@TypeOf(reader)){
+        .allocator = allocator,
         .line_buffer = std.ArrayList(u8).init(allocator),
         .reader = reader,
         .comment_characters = comment_characters,

--- a/src/lib-test.zig
+++ b/src/lib-test.zig
@@ -6,7 +6,7 @@ const c = @cImport({
 
 test "parser create/destroy" {
     var buffer: c.ini_Parser = undefined;
-    c.ini_create_buffer(&buffer, "", 0);
+    c.ini_create_buffer(&buffer, "", 0, "", 0);
     c.ini_destroy(&buffer);
 }
 
@@ -71,7 +71,7 @@ test "buffer parser" {
     ;
 
     var parser: c.ini_Parser = undefined;
-    c.ini_create_buffer(&parser, slice, slice.len);
+    c.ini_create_buffer(&parser, slice, slice.len, ";#", 2);
     defer c.ini_destroy(&parser);
 
     try commonTest(&parser);
@@ -82,7 +82,7 @@ test "file parser" {
     defer _ = c.fclose(file);
 
     var parser: c.ini_Parser = undefined;
-    c.ini_create_file(&parser, file);
+    c.ini_create_file(&parser, file, ";#", 2);
     defer c.ini_destroy(&parser);
 
     try commonTest(&parser);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -62,20 +62,20 @@ comptime {
         @compileError("align mismatch: ini_KeyValuePair struct does not match Record.KeyValuePair!");
 }
 
-export fn ini_create_buffer(parser: *IniParser, data: [*]const u8, length: usize) void {
+export fn ini_create_buffer(parser: *IniParser, data: [*]const u8, data_length: usize, comment_characters: [*]const u8, comment_characters_length: usize) void {
     parser.* = IniParser{
         .buffer = .{
-            .stream = std.io.fixedBufferStream(data[0..length]),
+            .stream = std.io.fixedBufferStream(data[0..data_length]),
             .parser = undefined,
         },
     };
     // this is required to have the parser store a pointer to the stream.
-    parser.buffer.parser = ini.parse(std.heap.c_allocator, parser.buffer.stream.reader());
+    parser.buffer.parser = ini.parse(std.heap.c_allocator, parser.buffer.stream.reader(), comment_characters[0..comment_characters_length]);
 }
 
-export fn ini_create_file(parser: *IniParser, file: *std.c.FILE) void {
+export fn ini_create_file(parser: *IniParser, file: *std.c.FILE, comment_characters: [*]const u8, comment_characters_length: usize) void {
     parser.* = IniParser{
-        .file = ini.parse(std.heap.c_allocator, cReader(file)),
+        .file = ini.parse(std.heap.c_allocator, cReader(file), comment_characters[0..comment_characters_length]),
     };
 }
 

--- a/src/test.zig
+++ b/src/test.zig
@@ -23,7 +23,7 @@ fn expectEnumeration(enumeration: []const u8, record: ?Record) !void {
 
 test "empty file" {
     var stream = std.io.fixedBufferStream("");
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectNull(try parser.next());
@@ -34,7 +34,7 @@ test "empty file" {
 
 test "section" {
     var stream = std.io.fixedBufferStream("[Hello]");
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectSection("Hello", try parser.next());
@@ -61,7 +61,7 @@ test "key-value-pair" {
         "  key  =  value  ",
     }) |pattern| {
         var stream = std.io.fixedBufferStream(pattern);
-        var parser = parse(std.testing.allocator, stream.reader());
+        var parser = parse(std.testing.allocator, stream.reader(), ";#");
         defer parser.deinit();
 
         try expectKeyValue("key", "value", try parser.next());
@@ -71,7 +71,7 @@ test "key-value-pair" {
 
 test "enumeration" {
     var stream = std.io.fixedBufferStream("enum");
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectEnumeration("enum", try parser.next());
@@ -80,7 +80,7 @@ test "enumeration" {
 
 test "empty line skipping" {
     var stream = std.io.fixedBufferStream("item a\r\n\r\n\r\nitem b");
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectEnumeration("item a", try parser.next());
@@ -90,7 +90,7 @@ test "empty line skipping" {
 
 test "multiple sections" {
     var stream = std.io.fixedBufferStream("  [Hello] \r\n[Foo Bar]\n[Hello!]\n");
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectSection("Hello", try parser.next());
@@ -101,7 +101,7 @@ test "multiple sections" {
 
 test "multiple properties" {
     var stream = std.io.fixedBufferStream("a = b\r\nc =\r\nkey value = core property");
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectKeyValue("a", "b", try parser.next());
@@ -112,7 +112,7 @@ test "multiple properties" {
 
 test "multiple enumeration" {
     var stream = std.io.fixedBufferStream(" a  \n b  \r\n c  ");
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectEnumeration("a", try parser.next());
@@ -133,7 +133,7 @@ test "mixed data" {
         \\Bat Out of Hell
         \\The Dark Side of the Moon
     );
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectSection("Meta", try parser.next());
@@ -156,7 +156,7 @@ test "# comments" {
         \\key = value # comment
         \\enum # comment
     );
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectSection("section", try parser.next());
@@ -172,7 +172,7 @@ test "; comments" {
         \\key = value ; comment
         \\enum ; comment
     );
-    var parser = parse(std.testing.allocator, stream.reader());
+    var parser = parse(std.testing.allocator, stream.reader(), ";#");
     defer parser.deinit();
 
     try expectSection("section", try parser.next());


### PR DESCRIPTION
Hello! This PR addresses an issue I've had in my program when parsing comments. These are 2 valid options in the program:

```ini
asterisk = #
```

and

```ini
DesktopNames = Budgie;GNOME
```

For the first one, I did what @ikskuh suggested instead and added support for escaping a comment character if needed. For example, this:

```ini
# This comment should be ignored
#
# Amazing!
names = Budgie;GNOME # Don't mind me
asterisk = \# # A comment character as an asterisk? Surely that can't break anything... right?
no_value = #This doesn't have any value
```

gets parsed into this:

```ini
names = Budgie
asterisk = #
no_value =
```

For the second option, I've simply added a way to configure the array of comment characters when creating the parser. I made sure to modify the C API and tests as well, and of course, all tests continue to pass.