### PR TITLE
Fix small escaping bug

### DIFF
--- a/src/ini.zig
+++ b/src/ini.zig
@@ -72,6 +72,7 @@ pub fn Parser(comptime Reader: type) type {
 
                             if (previous_char == '\\') {
                                 _ = self.line_buffer.orderedRemove(previous_index);
+                                line = self.line_buffer.items;
 
                                 last_index = index + 1;
                                 continue;

--- a/src/test.zig
+++ b/src/test.zig
@@ -189,6 +189,7 @@ test "comment escaping" {
         \\# Amazing!
         \\names = Budgie;GNOME # Don't mind me
         \\asterisk = \# # An asterisk as a comment character? Surely that can't break anything... right?
+        \\escaped = \#
         \\no_value = #This doesn't have any value
     );
     var parser = parse(std.testing.allocator, stream.reader(), "#");
@@ -196,6 +197,7 @@ test "comment escaping" {
 
     try expectKeyValue("names", "Budgie;GNOME", try parser.next());
     try expectKeyValue("asterisk", "#", try parser.next());
+    try expectKeyValue("escaped", "#", try parser.next());
     try expectKeyValue("no_value", "", try parser.next());
 
     try expectNull(try parser.next());


### PR DESCRIPTION
Hi! This PR fixes a small bug in the escaping code. Essentially, the `orderedRemove` function invalidates all items past the one at the removed index, but the code doesn't reset the `line` variable to the current `items` slice. This could lead to unwanted characters right after an escaped comment character.
This PR fixes that, and adds a test for the affected use case.