### PR TITLE
Update to Zig 0.15.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Build and Test
     steps:
       - uses: actions/checkout@v3
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
         with:
           version: 0.15.0
       - run: zig build test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.14.0
+          version: 0.15.0
       - run: zig build test

--- a/build.zig
+++ b/build.zig
@@ -8,11 +8,13 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/ini.zig"),
     });
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "ini",
-        .root_source_file = b.path("src/lib.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/lib.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     lib.bundle_compiler_rt = true;
     lib.addIncludePath(b.path("src"));
@@ -23,8 +25,10 @@ pub fn build(b: *std.Build) void {
     const example_step = b.step("example", "Build examples");
     const example_c = b.addExecutable(.{
         .name = "example-c",
-        .optimize = optimize,
-        .target = target,
+        .root_module = b.createModule(.{
+            .optimize = optimize,
+            .target = target,
+        }),
     });
     example_c.addCSourceFile(.{
         .file = b.path("example/example.c"),
@@ -41,23 +45,31 @@ pub fn build(b: *std.Build) void {
 
     const example_zig = b.addExecutable(.{
         .name = "example-zig",
-        .root_source_file = b.path("example/example.zig"),
-        .optimize = optimize,
-        .target = target,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("example/example.zig"),
+            .optimize = optimize,
+            .target = target,
+        }),
     });
     example_zig.root_module.addImport("ini", b.modules.get("ini").?);
     example_step.dependOn(&b.addInstallArtifact(example_zig, .{}).step);
 
     const test_step = b.step("test", "Run library tests");
     const main_tests = b.addTest(.{
-        .root_source_file = b.path("src/test.zig"),
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/test.zig"),
+            .optimize = optimize,
+            .target = target,
+        }),
     });
     test_step.dependOn(&b.addRunArtifact(main_tests).step);
 
     const binding_tests = b.addTest(.{
-        .root_source_file = b.path("src/lib-test.zig"),
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/lib-test.zig"),
+            .optimize = optimize,
+            .target = target,
+        }),
     });
     binding_tests.addIncludePath(b.path("src"));
     binding_tests.linkLibrary(lib);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .ini,
     .fingerprint = 0x7757b668623d2460,
     .version = "0.1.0",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0",
     .paths = .{
         "LICENCE",
         "README.md",

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -39,7 +39,7 @@ pub fn Parser(comptime Reader: type) type {
         const Self = @This();
 
         allocator: std.mem.Allocator,
-        line_buffer: std.ArrayList(u8),
+        line_buffer: std.array_list.Managed(u8),
         reader: Reader,
         comment_characters: []const u8,
 
@@ -114,7 +114,7 @@ pub fn Parser(comptime Reader: type) type {
 pub fn parse(allocator: std.mem.Allocator, reader: anytype, comment_characters: []const u8) Parser(@TypeOf(reader)) {
     return Parser(@TypeOf(reader)){
         .allocator = allocator,
-        .line_buffer = std.ArrayList(u8).init(allocator),
+        .line_buffer = std.array_list.Managed(u8).init(allocator),
         .reader = reader,
         .comment_characters = comment_characters,
     };

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -131,7 +131,7 @@ export fn ini_next(parser: *IniParser, record: *Record) IniError {
     return .success;
 }
 
-const CReader = std.io.Reader(*std.c.FILE, std.fs.File.ReadError, cReaderRead);
+const CReader = std.Io.GenericReader(*std.c.FILE, std.fs.File.ReadError, cReaderRead);
 
 fn cReader(c_file: *std.c.FILE) CReader {
     return .{ .context = c_file };


### PR DESCRIPTION
Hello! This PR adds support for Zig 0.15.0. I've made this a draft because all I've done so far is make the code work with the deprecated APIs (specifically the I/O and array list APIs). I've done some more work offline to port the code to use the new APIs, but so far I've been unable to make it work. Though, if you think this is enough for supporting the new version, feel free to merge it because the code works & all tests (including C tests) pass!

Also, I haven't modified the version (it currently is set to `0.1.0`) because it hasn't been tagged yet. Should it still be changed or not?